### PR TITLE
Implemented support for the new ShortUrl endpoints

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -482,7 +482,7 @@ Imbo uses access tokens in the URLs to prevent `DoS attacks <http://en.wikipedia
 ``getMetadataUrl(imageIdentifier)``
     Fetch URL to the metadata of a specific image.
 
-``getShortUrl(imageUrl)``
+``getShortUrl(imageUrl, callback)``
     Fetch the short URL to an image (with optional image transformations added).
 
 All these methods return instances of different classes, and all can be used in string context to get the URL with the access token added. The instance returned from the ``getImageUrl`` is somewhat special since it will let you chain a set of transformations before generating the URL as a string:
@@ -544,9 +544,47 @@ There are also some other methods available:
     Proxies to ``convert('png')``.
 
 ``reset()``
-    Removes all transformations added to the URL instance.
+    Removes all transformations added to the ImageUrl instance.
+
+``clone()``
+    Creates a clone of the ImageUrl instance.
 
 The methods related to the image type (``convert`` and the proxy methods) can be added anywhere in the chain. Otherwise all transformations will be applied to the image in the same order as they appear in the chain.
+
+ShortUrls
++++++++++
+
+With the host, user, image identifier, transformations and access tokens all being part of an image URL, the URLs can become quite long. Imbo supports making shorter URLs, which follows this pattern: ``http://imbo.host/s/ShortId``.
+
+Instances of ``ShortUrl`` contains both the short URL (retrieved by calling ``shortUrl.toString()``) and the ID of the short URL (``shortUrl.getId()``). This ID can be used with ``deleteShortUrlForImage`` if you should wish to remove the short URL at a later time.
+
+The available methods related to short URLs are:
+
+``getShortUrl(imageUrl, callback)``
+    Generates a ``ShortUrl``. ``imageUrl`` is an instance of ``Imbo.ImageUrl``
+
+``deleteAllShortUrlsForImage(imageIdentifier, callback)``
+    Deletes every short URL that has been generated for the given image identifier.
+
+``deleteShortUrlForImage(imageIdentifier, shortUrl, callback)``
+    Deletes a specific short URL. ``shortUrl`` can be either a ``ShortUrl`` instance or the ID of a short URL.
+
+.. code-block:: js
+
+    var url = client.getImageUrl(imageIdentifier).thumbnail();
+    
+    client.getShortUrl(url, function(err, shortUrl) {
+        if (err) {
+            return console.error('An error occured: ' + err);
+        }
+
+        console.log('ShortUrl generated: ' + shortUrl.toString());
+
+        // To delete the short URL:
+        client.deleteShortUrlForImage(imageIdentifier, shortUrl, function(err) {
+            console.log(err ? ('An error occured: ' + err) : 'ShortUrl deleted');
+        });
+    });
 
 Get server status
 +++++++++++++++++

--- a/examples/node/add-remove.js
+++ b/examples/node/add-remove.js
@@ -62,15 +62,21 @@ client.imageExists(img, function(err, exists, imageIdentifier) {
             console.log('URL: ' + url);
 
             // Bit more interesting, lets add some transformations:
-            url.thumbnail(200, 200).border('000', 5, 5);
+            url.thumbnail({ width: 200, height: 200 }).border({ color: '000', width: 5, height: 5 });
             console.log('Transformed URL: ' + url);
 
             // Maybe we just want to flip it, instead?
             url.reset().flipVertically();
             console.log('Vertically flipped: ' + url);
 
-            // And we're done
-            console.log('All done...');
+            // Or maybe we want a short URL to the image, with some transformations?
+            url.reset().maxSize({ width: 640 }).sepia().png();
+            client.getShortUrl(url, function(err, shortUrl) {
+                console.log('ShortURL: ' + shortUrl.toString());
+
+                // And we're done
+                console.log('All done...');
+            });
         });
 
     }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@
  * distributed with this source code.
  */
 exports.Client   = require('./lib/client');
-exports.Url      = require('./lib/url');
-exports.ImageUrl = require('./lib/imageurl');
+exports.Url      = require('./lib/url/url');
+exports.ImageUrl = require('./lib/url/imageurl');
+exports.ShortUrl = require('./lib/url/shorturl');
 exports.Query    = require('./lib/query');
 exports.Version  = require('./package.json').version;

--- a/lib/client.js
+++ b/lib/client.js
@@ -8,8 +8,9 @@
  */
 'use strict';
 
-var ImboUrl   = require('./url'),
-    ImageUrl  = require('./imageurl'),
+var ImboUrl   = require('./url/url'),
+    ImageUrl  = require('./url/imageurl'),
+    ShortUrl  = require('./url/shorturl'),
     ImboQuery = require('./query'),
     extend    = require('./utils/extend'),
     jsonparse = require('./utils/jsonparse'),
@@ -407,15 +408,65 @@ extend(ImboClient.prototype, {
      * @param {Function}      callback
      */
     getShortUrl: function(imageUrl, callback) {
-        request.head(imageUrl.toString(), function(err, res) {
-            if (err) {
-                return callback(err);
-            } else if (!res || !res.headers['x-imbo-shorturl']) {
-                return callback('No ShortUrl was returned from server');
-            }
+        var url       = imageUrl.clone(),
+            extension = url.getExtension(),
+            imageId   = url.getImageIdentifier(),
+            host      = this.getHostForImageIdentifier(imageId),
+            data      = {
+                'imageIdentifier': imageId,
+                'publicKey': url.getPublicKey(),
+                'query': url.getQueryString(),
+            };
 
-            callback(err, res.headers['x-imbo-shorturl']);
+        if (extension) {
+            data.extension = extension;
+        }
+
+        // Reset to remove transformations/query string
+        url.reset().setPath('/shorturls');
+
+        request({
+            method    : 'POST',
+            uri       : this.getSignedResourceUrl('POST', url.toString()),
+            json      : data,
+            onComplete: function(err, res, body) {
+                if (err) {
+                    return callback(err);
+                } else if (!body || !body.id) {
+                    return callback('No ShortUrl was returned from server');
+                }
+
+                callback(err, new ShortUrl({ 'baseUrl': host, 'id': body.id }));
+            }
         });
+    },
+
+    /**
+     * Delete all ShortUrls for a given imageIdentifier
+     *
+     * @param {String}   imageIdentifier
+     * @param {Function} callback
+     */
+    deleteAllShortUrlsForImage: function(imageIdentifier, callback) {
+        var url    = this.getImageUrl(imageIdentifier).setPath('/shorturls'),
+            signed = this.getSignedResourceUrl('DELETE', url);
+
+        request.del(signed, callback);
+    },
+
+    /**
+     * Delete a ShortUrl for a given imageIdentifier
+     *
+     * @param {String|Imbo.ShortUrl} shortUrl
+     * @param {String}               imageIdentifier
+     * @param {Function}             callback
+     */
+    deleteShortUrlForImage: function(imageIdentifier, shortUrl, callback) {
+        var id     = shortUrl instanceof ShortUrl ? shortUrl.getId() : shortUrl,
+            url    = this.getImageUrl(imageIdentifier).setPath('/shorturls/' + id),
+            signed = this.getSignedResourceUrl('DELETE', url);
+
+        request.del(signed, callback);
     },
 
     /**

--- a/lib/url/imageurl.js
+++ b/lib/url/imageurl.js
@@ -9,7 +9,8 @@
 'use strict';
 
 var ImboUrl = require('./url'),
-    extend  = require('./utils/extend');
+    extend  = require('../utils/extend'),
+    clone   = require('clone');
 
 // Simple function wrappers for better readability and compression
 var toInt = function(num) { return parseInt(num, 10); },
@@ -28,7 +29,7 @@ var ImageUrl = function(options) {
     this.publicKey = options.publicKey;
     this.privateKey = options.privateKey;
     this.imageIdentifier = options.imageIdentifier || '';
-    this.extension = '';
+    this.extension = options.extension;
     this.queryString = options.queryString;
     this.path = options.path || '';
 
@@ -134,7 +135,7 @@ extend(ImageUrl.prototype, {
      * @return {Imbo.ImageUrl}
      */
     convert: function(type) {
-        this.extension = '.' + type;
+        this.extension = type;
         return this;
     },
 
@@ -460,9 +461,18 @@ extend(ImageUrl.prototype, {
      * @return {Imbo.ImageUrl}
      */
     reset: function() {
-        this.extension = '';
+        this.extension = undefined;
         this.transformations = [];
         return this;
+    },
+
+    /**
+     * Clone this ImageUrl instance
+     *
+     * @return {Imbo.ImageUrl}
+     */
+    clone: function() {
+        return clone(this);
     },
 
     /**
@@ -483,6 +493,24 @@ extend(ImageUrl.prototype, {
      */
     getTransformations: function() {
         return this.transformations;
+    },
+
+    /**
+     * Get the specified extension of the image (if any)
+     *
+     * @return {String}
+     */
+    getExtension: function() {
+        return this.extension;
+    },
+
+    /**
+     * Return the image identifier for this ImageUrl instance
+     *
+     * @return {String}
+     */
+    getImageIdentifier: function() {
+        return this.imageIdentifier;
     },
 
     /**

--- a/lib/url/shorturl.js
+++ b/lib/url/shorturl.js
@@ -1,0 +1,54 @@
+/**
+ * This file is part of the imboclient-js package
+ *
+ * (c) Espen Hovlandsdal <espen@hovlandsdal.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+'use strict';
+
+var extend = require('../utils/extend');
+
+/**
+ * ShortUrl constructor
+ *
+ * @param {Object} options
+ */
+var ShortUrl = function(options) {
+    options = options || {};
+
+    this.baseUrl = options.baseUrl;
+    this.shortId = options.id;
+};
+
+extend(ShortUrl.prototype, {
+    /**
+     * Get the ID of the short URL
+     *
+     * @return {String}
+     */
+    getId: function() {
+        return this.shortId;
+    },
+
+    /**
+     * Get a string representation of the URL
+     *
+     * @return {String}
+     */
+    getUrl: function() {
+        return this.baseUrl + '/s/' + this.shortId;
+    },
+
+    /**
+     * Alias of getUrl()
+     *
+     * @return {String}
+     */
+    toString: function() {
+        return this.getUrl();
+    }
+});
+
+module.exports = ShortUrl;

--- a/lib/url/url.js
+++ b/lib/url/url.js
@@ -8,8 +8,8 @@
  */
 'use strict';
 
-var crypto = require('./node/crypto'),
-    extend = require('./utils/extend');
+var crypto = require('../node/crypto'),
+    extend = require('../utils/extend');
 
 /**
  * ImboUrl constructor
@@ -23,13 +23,22 @@ var ImboUrl = function(options) {
     this.baseUrl = options.baseUrl;
     this.publicKey = options.publicKey;
     this.privateKey = options.privateKey;
-    this.extension = options.extension || '';
+    this.extension = options.extension;
     this.imageIdentifier = options.imageIdentifier || '';
     this.path = options.path || '';
     this.queryString = options.queryString;
 };
 
 extend(ImboUrl.prototype, {
+    /**
+     * Get the public key for this URL instance
+     *
+     * @return {String}
+     */
+    getPublicKey: function() {
+        return this.publicKey;
+    },
+
     /**
      * Get the path part of the URL
      *
@@ -86,7 +95,8 @@ extend(ImboUrl.prototype, {
      * @return {String}
      */
     getUrl: function() {
-        var url        = (this.baseUrl + this.extension + this.path),
+        var extension  = this.extension ? ('.' + this.extension) : '',
+            url        = (this.baseUrl + extension + this.path),
             encodedUrl = url,
             qs         = this.getQueryString();
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "url": "http://github.com/imbo/imboclient-js/issues"
     },
     "dependencies": {
-        "request": "~2.34.0"
+        "request": "~2.34.0",
+        "clone": "~0.1.11"
     },
     "devDependencies": {
         "grunt": "~0.4.2",

--- a/test/unit/imageurl.js
+++ b/test/unit/imageurl.js
@@ -389,6 +389,18 @@ describe('Imbo.ImageUrl', function() {
         });
     });
 
+    describe('#clone', function() {
+        it('should return a clone of itself', function() {
+            url.flipHorizontally().thumbnail();
+
+            var clone = url.clone();
+            assert.equal(url.toString(), clone.toString());
+
+            clone.border();
+            assert.notEqual(url.toString(), clone.toString());
+        });
+    });
+
     describe('#append', function() {
         it('should append to the transformations array', function() {
             url.append('custom:foo=bar').toString().should.include('http://imbo/users/pub/images/61da9892205a0d5077a353eb3487e8c8?t%5B%5D=custom%3Afoo%3Dbar');

--- a/test/unit/shorturl.js
+++ b/test/unit/shorturl.js
@@ -1,0 +1,31 @@
+var Imbo    = require('../../'),
+    assert  = require('assert'),
+    shortId = 'imboF00';
+
+describe('Imbo.ShortUrl', function() {
+
+    var baseUrl = 'http://imbo',
+        url = new Imbo.ShortUrl({
+            baseUrl: baseUrl,
+            id: shortId
+        });
+
+    describe('#getId', function() {
+        it('should return the set ShortUrl ID', function() {
+            assert.equal(url.getId(), shortId);
+        });
+    });
+
+    describe('#getUrl', function() {
+        it('should return the correct URL', function() {
+            assert.equal(url.getUrl(), baseUrl + '/s/' + shortId);
+        });
+    });
+
+    describe('#toString', function() {
+        it('should alias getUrl()', function() {
+            assert.equal(url.toString(), url.getUrl());
+        });
+    });
+
+});


### PR DESCRIPTION
This PR lands support for the new ShortUrl endpoints. Introduced methods:
- `getShortUrl(imageIdentifier, callback)`
- `deleteAllShortUrlsForImage(imageIdentifier, callback)``
- `deleteShortUrlForImage(imageIdentifier, shortUrl, callback)`

Documentation has also been updated to reflect the changes, and a new `ShortUrl`-class has been introduced.
