### PR TITLE
Replace SHA-library

### DIFF
--- a/lib/browser/crypto.js
+++ b/lib/browser/crypto.js
@@ -19,10 +19,11 @@ var supportsWebWorkers = function() {
     }
 
     try {
-        /* eslint no-new: 0 */
+        /* eslint-disable no-new */
         new Worker(window.URL.createObjectURL(
             new Blob([''], { type: 'text/javascript' })
         ));
+        /* eslint-enable no-new */
     } catch (e) {
         return false;
     }
@@ -30,7 +31,7 @@ var supportsWebWorkers = function() {
     return true;
 };
 
-var sha = require('./sha'),
+var Sha = require('./sha'),
     md5 = require('./md5.min'),
     readers = require('./readers');
 
@@ -95,7 +96,10 @@ module.exports = {
      * @return {String}
      */
     sha256: function(key, data) {
-        return sha.sha256hmac(key, data);
+        var shaObj = new Sha('SHA-256', 'TEXT');
+        shaObj.setHMACKey(key, 'TEXT');
+        shaObj.update(data);
+        return shaObj.getHMAC('HEX');
     },
 
     /**

--- a/lib/browser/sha.js
+++ b/lib/browser/sha.js
@@ -1,154 +1,657 @@
 /**
- * This is based on the following work:
+ * @preserve A JavaScript implementation of the SHA family of hashes, as
+ * defined in FIPS PUB 180-2 as well as the corresponding HMAC implementation
+ * as defined in FIPS PUB 198a
  *
- * A JavaScript implementation of the Secure Hash Algorithm, SHA-256,
- * as defined in FIPS 180-2
+ * Copyright Brian Turek 2008-2015
+ * Distributed under the BSD License
+ * See http://caligatio.github.com/jsSHA/ for more information
  *
- * Version 2.2-beta Copyright Angel Marin, Paul Johnston 2000 - 2009.
- * Other contributors: Greg Holt, Andrew Kepert, Ydnar, Lostinet
+ * Several functions taken from Paul Johnston
+ * Stripped by Espen Hovlandsdal to only include the methods required for
+ * hmac-sha256 in utf8 format, used in imboclient-js
  */
 
-/* eslint no-bitwise: 0 */
+/* eslint-disable */
 'use strict';
 
-var chrsz = 8;
+/**
+ * Convert a string to an array of big-endian words
+ *
+ * There is a known bug with an odd number of existing bytes and using a
+ * UTF-16 encoding.  However, this function is used such that the existing
+ * bytes are always a result of a previous UTF-16 str2binb call and
+ * therefore there should never be an odd number of existing bytes
+ *
+ * @private
+ * @param {string} str String to be converted to binary representation
+ * @param {string} utfType The Unicode type, UTF8 or UTF16BE, UTF16LE, to
+ *   use to encode the source string
+ * @param {Array.<number>} existingBin A packed int array of bytes to
+ *   append the results to
+ * @param {number} existingBinLen The number of bits in the existingBin
+ *   array
+ * @return {{value : Array.<number>, binLen : number}} Hash list where
+ *   "value" contains the output number array and "binLen" is the binary
+ *   length of "value"
+ */
+function str2binb(str, utfType, existingBin, existingBinLen) {
+    var bin = [], codePnt, binArr = [], byteCnt = 0, i, j, existingByteLen,
+        intOffset, byteOffset;
 
-var safeAdd = function(x, y) {
-    var lsw = (x & 0xFFFF) + (y & 0xFFFF);
-    var msw = (x >> 16) + (y >> 16) + (lsw >> 16);
-    return (msw << 16) | (lsw & 0xFFFF);
-};
+    bin = existingBin || [0];
+    existingBinLen = existingBinLen || 0;
+    existingByteLen = existingBinLen >>> 3;
 
-var s = function(X, n) {
-    return (X >>> n) | (X << (32 - n));
-};
+    for (i = 0; i < str.length; i += 1)
+    {
+        codePnt = str.charCodeAt(i);
+        binArr = [];
 
-var r = function(X, n) {
-    return (X >>> n);
-};
-
-var ch = function(x, y, z) {
-    return ((x & y) ^ ((~x) & z));
-};
-
-var maj = function(x, y, z) {
-    return ((x & y) ^ (x & z) ^ (y & z));
-};
-
-var sigma0256 = function(x) {
-    return (s(x, 2) ^ s(x, 13) ^ s(x, 22));
-};
-
-var sigma1256 = function(x) {
-    return (s(x, 6) ^ s(x, 11) ^ s(x, 25));
-};
-
-var gamma0256 = function(x) {
-    return (s(x, 7) ^ s(x, 18) ^ r(x, 3));
-};
-
-var gamma1256 = function(x) {
-    return (s(x, 17) ^ s(x, 19) ^ r(x, 10));
-};
-
-var coreSha256 = function(m, l) {
-    var K = [
-        0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5, 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5, 0xD807AA98,
-        0x12835B01, 0x243185BE, 0x550C7DC3, 0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174, 0xE49B69C1, 0xEFBE4786,
-        0xFC19DC6, 0x240CA1CC, 0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA, 0x983E5152, 0xA831C66D, 0xB00327C8,
-        0xBF597FC7, 0xC6E00BF3, 0xD5A79147, 0x6CA6351, 0x14292967, 0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
-        0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85, 0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3, 0xD192E819,
-        0xD6990624, 0xF40E3585, 0x106AA070, 0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5, 0x391C0CB3, 0x4ED8AA4A,
-        0x5B9CCA4F, 0x682E6FF3, 0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208, 0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7,
-        0xC67178F2
-    ];
-    var HASH = [0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19];
-    var W = new Array(64);
-    var a, b, c, d, e, f, g, h, i, j;
-    var T1, T2;
-
-    // append padding
-    m[l >> 5] |= 0x80 << (24 - l % 32);
-    m[((l + 64 >> 9) << 4) + 15] = l;
-
-    for (i = 0; i < m.length; i += 16) {
-        a = HASH[0];
-        b = HASH[1];
-        c = HASH[2];
-        d = HASH[3];
-        e = HASH[4];
-        f = HASH[5];
-        g = HASH[6];
-        h = HASH[7];
-
-        for (j = 0; j < 64; j++) {
-            if (j < 16) {
-                W[j] = m[j + i];
-            } else {
-                W[j] = safeAdd(safeAdd(safeAdd(gamma1256(W[j - 2]), W[j - 7]), gamma0256(W[j - 15])), W[j - 16]);
-            }
-            T1 = safeAdd(safeAdd(safeAdd(safeAdd(h, sigma1256(e)), ch(e, f, g)), K[j]), W[j]);
-            T2 = safeAdd(sigma0256(a), maj(a, b, c));
-
-            h = g;
-            g = f;
-            f = e;
-            e = safeAdd(d, T1);
-            d = c;
-            c = b;
-            b = a;
-            a = safeAdd(T1, T2);
+        if (0x80 > codePnt)
+        {
+            binArr.push(codePnt);
+        }
+        else if (0x800 > codePnt)
+        {
+            binArr.push(0xC0 | (codePnt >>> 6));
+            binArr.push(0x80 | (codePnt & 0x3F));
+        }
+        else if ((0xd800 > codePnt) || (0xe000 <= codePnt)) {
+            binArr.push(
+                0xe0 | (codePnt >>> 12),
+                0x80 | ((codePnt >>> 6) & 0x3f),
+                0x80 | (codePnt & 0x3f)
+            );
+        }
+        else
+        {
+            i += 1;
+            codePnt = 0x10000 + (((codePnt & 0x3ff) << 10) | (str.charCodeAt(i) & 0x3ff));
+            binArr.push(
+                0xf0 | (codePnt >>> 18),
+                0x80 | ((codePnt >>> 12) & 0x3f),
+                0x80 | ((codePnt >>> 6) & 0x3f),
+                0x80 | (codePnt & 0x3f)
+            );
         }
 
-        HASH[0] = safeAdd(a, HASH[0]);
-        HASH[1] = safeAdd(b, HASH[1]);
-        HASH[2] = safeAdd(c, HASH[2]);
-        HASH[3] = safeAdd(d, HASH[3]);
-        HASH[4] = safeAdd(e, HASH[4]);
-        HASH[5] = safeAdd(f, HASH[5]);
-        HASH[6] = safeAdd(g, HASH[6]);
-        HASH[7] = safeAdd(h, HASH[7]);
+        for (j = 0; j < binArr.length; j += 1)
+        {
+            byteOffset = byteCnt + existingByteLen;
+            intOffset = byteOffset >>> 2;
+            while (bin.length <= intOffset)
+            {
+                bin.push(0);
+            }
+            /* Known bug kicks in here */
+            bin[intOffset] |= binArr[j] << (8 * (3 - (byteOffset % 4)));
+            byteCnt += 1;
+        }
     }
 
-    return HASH;
-};
+    return {"value" : bin, "binLen" : byteCnt * 8 + existingBinLen};
+}
 
-var str2binb = function(str) {
-    var bin = [];
-    var mask = (1 << chrsz) - 1;
-    for (var i = 0; i < str.length * chrsz; i += chrsz) {
-        bin[i >> 5] |= (str.charCodeAt(i / chrsz) & mask) << (24 - i % 32);
-    }
-    return bin;
-};
+/**
+ * Convert an array of big-endian words to a hex string.
+ *
+ * @private
+ * @param {Array.<number>} binarray Array of integers to be converted to
+ *   hexidecimal representation
+ * @param {{b64Pad : string}} formatOpts Hash list
+ *   containing validated output formatting options
+ * @return {string} Hexidecimal representation of the parameter in string
+ *   form
+ */
+function binb2hex(binarray, formatOpts)
+{
+    var hex_tab = "0123456789abcdef", str = "",
+        length = binarray.length * 4, i, srcByte;
 
-var binb2hex = function(binarray) {
-    var hexTab = '0123456789abcdef', str = '';
-    for (var i = 0; i < binarray.length * 4; i++) {
-        str += (
-            hexTab.charAt((binarray[i >> 2] >> ((3 - i % 4) * 8 + 4)) & 0xF) +
-            hexTab.charAt((binarray[i >> 2] >> ((3 - i % 4) * 8)) & 0xF)
-        );
+    for (i = 0; i < length; i += 1)
+    {
+        /* The below is more than a byte but it gets taken care of later */
+        srcByte = binarray[i >>> 2] >>> ((3 - (i % 4)) * 8);
+        str += hex_tab.charAt((srcByte >>> 4) & 0xF) +
+            hex_tab.charAt(srcByte & 0xF);
     }
+
     return str;
-};
+}
 
-var coreHmacSha256 = function(key, data) {
-    var bkey = str2binb(key);
-    if (bkey.length > 16) {
-        bkey = coreSha256(bkey, key.length * chrsz);
+/**
+ * Validate hash list containing output formatting options, ensuring
+ * presence of every option or adding the default value
+ *
+ * @private
+ * @param {{outputUpper : (boolean|undefined), b64Pad : (string|undefined)}=}
+ *   options Hash list of output formatting options
+ * @return {{outputUpper : boolean, b64Pad : string}} Validated hash list
+ *   containing output formatting options
+ */
+function getOutputOpts(options)
+{
+    var retVal = {"outputUpper" : false, "b64Pad" : "="}, outputOptions;
+    outputOptions = options || {};
+
+    return retVal;
+}
+
+/**
+ * Function that takes an input format and UTF encoding and returns the
+ * appropriate function used to convert the input.
+ *
+ * @private
+ * @param {string} format The format of the string to be converted
+ * @param {string} utfType The string encoding to use (UTF8, UTF16BE,
+ *  UTF16LE)
+ * @return {function(string, Array.<number>=, number=): {value :
+ *   Array.<number>, binLen : number}} Function that will convert an input
+ *   string to a packed int array
+ */
+function getStrConverter(format, utfType)
+{
+    return function(str, existingBin, existingBinLen) {
+        return str2binb(str, utfType, existingBin, existingBinLen);
+    };
+}
+
+/**
+ * The 32-bit implementation of circular rotate right
+ *
+ * @private
+ * @param {number} x The 32-bit integer argument
+ * @param {number} n The number of bits to shift
+ * @return {number} The x shifted circularly by n bits
+ */
+function rotr_32(x, n)
+{
+    return (x >>> n) | (x << (32 - n));
+}
+
+/**
+ * The 32-bit implementation of shift right
+ *
+ * @private
+ * @param {number} x The 32-bit integer argument
+ * @param {number} n The number of bits to shift
+ * @return {number} The x shifted by n bits
+ */
+function shr_32(x, n)
+{
+    return x >>> n;
+}
+
+/**
+ * The 32-bit implementation of the NIST specified Ch function
+ *
+ * @private
+ * @param {number} x The first 32-bit integer argument
+ * @param {number} y The second 32-bit integer argument
+ * @param {number} z The third 32-bit integer argument
+ * @return {number} The NIST specified output of the function
+ */
+function ch_32(x, y, z)
+{
+    return (x & y) ^ (~x & z);
+}
+
+/**
+ * The 32-bit implementation of the NIST specified Maj function
+ *
+ * @private
+ * @param {number} x The first 32-bit integer argument
+ * @param {number} y The second 32-bit integer argument
+ * @param {number} z The third 32-bit integer argument
+ * @return {number} The NIST specified output of the function
+ */
+function maj_32(x, y, z)
+{
+    return (x & y) ^ (x & z) ^ (y & z);
+}
+
+/**
+ * The 32-bit implementation of the NIST specified Sigma0 function
+ *
+ * @private
+ * @param {number} x The 32-bit integer argument
+ * @return {number} The NIST specified output of the function
+ */
+function sigma0_32(x)
+{
+    return rotr_32(x, 2) ^ rotr_32(x, 13) ^ rotr_32(x, 22);
+}
+
+/**
+ * The 32-bit implementation of the NIST specified Sigma1 function
+ *
+ * @private
+ * @param {number} x The 32-bit integer argument
+ * @return {number} The NIST specified output of the function
+ */
+function sigma1_32(x)
+{
+    return rotr_32(x, 6) ^ rotr_32(x, 11) ^ rotr_32(x, 25);
+}
+
+/**
+ * The 32-bit implementation of the NIST specified Gamma0 function
+ *
+ * @private
+ * @param {number} x The 32-bit integer argument
+ * @return {number} The NIST specified output of the function
+ */
+function gamma0_32(x)
+{
+    return rotr_32(x, 7) ^ rotr_32(x, 18) ^ shr_32(x, 3);
+}
+
+/**
+ * The 32-bit implementation of the NIST specified Gamma1 function
+ *
+ * @private
+ * @param {number} x The 32-bit integer argument
+ * @return {number} The NIST specified output of the function
+ */
+function gamma1_32(x)
+{
+    return rotr_32(x, 17) ^ rotr_32(x, 19) ^ shr_32(x, 10);
+}
+
+/**
+ * Add two 32-bit integers, wrapping at 2^32. This uses 16-bit operations
+ * internally to work around bugs in some JS interpreters.
+ *
+ * @private
+ * @param {number} a The first 32-bit integer argument to be added
+ * @param {number} b The second 32-bit integer argument to be added
+ * @return {number} The sum of a + b
+ */
+function safeAdd_32_2(a, b)
+{
+    var lsw = (a & 0xFFFF) + (b & 0xFFFF),
+        msw = (a >>> 16) + (b >>> 16) + (lsw >>> 16);
+
+    return ((msw & 0xFFFF) << 16) | (lsw & 0xFFFF);
+}
+
+/**
+ * Add four 32-bit integers, wrapping at 2^32. This uses 16-bit operations
+ * internally to work around bugs in some JS interpreters.
+ *
+ * @private
+ * @param {number} a The first 32-bit integer argument to be added
+ * @param {number} b The second 32-bit integer argument to be added
+ * @param {number} c The third 32-bit integer argument to be added
+ * @param {number} d The fourth 32-bit integer argument to be added
+ * @return {number} The sum of a + b + c + d
+ */
+function safeAdd_32_4(a, b, c, d)
+{
+    var lsw = (a & 0xFFFF) + (b & 0xFFFF) + (c & 0xFFFF) + (d & 0xFFFF),
+        msw = (a >>> 16) + (b >>> 16) + (c >>> 16) + (d >>> 16) +
+            (lsw >>> 16);
+
+    return ((msw & 0xFFFF) << 16) | (lsw & 0xFFFF);
+}
+
+/**
+ * Add five 32-bit integers, wrapping at 2^32. This uses 16-bit operations
+ * internally to work around bugs in some JS interpreters.
+ *
+ * @private
+ * @param {number} a The first 32-bit integer argument to be added
+ * @param {number} b The second 32-bit integer argument to be added
+ * @param {number} c The third 32-bit integer argument to be added
+ * @param {number} d The fourth 32-bit integer argument to be added
+ * @param {number} e The fifth 32-bit integer argument to be added
+ * @return {number} The sum of a + b + c + d + e
+ */
+function safeAdd_32_5(a, b, c, d, e)
+{
+    var lsw = (a & 0xFFFF) + (b & 0xFFFF) + (c & 0xFFFF) + (d & 0xFFFF) +
+            (e & 0xFFFF),
+        msw = (a >>> 16) + (b >>> 16) + (c >>> 16) + (d >>> 16) +
+            (e >>> 16) + (lsw >>> 16);
+
+    return ((msw & 0xFFFF) << 16) | (lsw & 0xFFFF);
+}
+
+/**
+ * Gets the H values for the specified SHA variant
+ *
+ * @param {string} variant The SHA variant
+ * @return {Array.<number|Int_64>} The initial H values
+ */
+function getH(variant)
+{
+    return [
+        0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
+        0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19
+    ];
+}
+
+/* Put this here so the K arrays aren't put on the stack for every block */
+var K_sha2 = [
+    0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,
+    0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
+    0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3,
+    0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
+    0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC,
+    0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
+    0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7,
+    0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
+    0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
+    0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
+    0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3,
+    0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
+    0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5,
+    0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
+    0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208,
+    0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2
+];
+
+/**
+ * Performs a round of SHA-2 hashing over a block
+ *
+ * @private
+ * @param {Array.<number>} block The binary array representation of the
+ *   block to hash
+ * @param {Array.<number|Int_64>} H The intermediate H values from a previous
+ *   round
+ * @param {string} variant The desired SHA-2 variant
+ * @return {Array.<number|Int_64>} The resulting H values
+ */
+function roundSHA2(block, H, variant)
+{
+    var a, b, c, d, e, f, g, h, T1, T2, numRounds, t, binaryStringMult,
+        safeAdd_2, safeAdd_4, safeAdd_5, gamma0, gamma1, sigma0, sigma1,
+        ch, maj, Int, W = [], int1, int2, offset, K;
+
+
+    /* 32-bit variant */
+    numRounds = 64;
+    binaryStringMult = 1;
+    Int = Number;
+    safeAdd_2 = safeAdd_32_2;
+    safeAdd_4 = safeAdd_32_4;
+    safeAdd_5 = safeAdd_32_5;
+    gamma0 = gamma0_32;
+    gamma1 = gamma1_32;
+    sigma0 = sigma0_32;
+    sigma1 = sigma1_32;
+    maj = maj_32;
+    ch = ch_32;
+    K = K_sha2;
+
+    a = H[0];
+    b = H[1];
+    c = H[2];
+    d = H[3];
+    e = H[4];
+    f = H[5];
+    g = H[6];
+    h = H[7];
+
+    for (t = 0; t < numRounds; t += 1)
+    {
+        if (t < 16)
+        {
+            offset = t * binaryStringMult;
+            int1 = (block.length <= offset) ? 0 : block[offset];
+            int2 = (block.length <= offset + 1) ? 0 : block[offset + 1];
+            /* Bit of a hack - for 32-bit, the second term is ignored */
+            W[t] = new Int(int1, int2);
+        }
+        else
+        {
+            W[t] = safeAdd_4(
+                    gamma1(W[t - 2]), W[t - 7],
+                    gamma0(W[t - 15]), W[t - 16]
+                );
+        }
+
+        T1 = safeAdd_5(h, sigma1(e), ch(e, f, g), K[t], W[t]);
+        T2 = safeAdd_2(sigma0(a), maj(a, b, c));
+        h = g;
+        g = f;
+        f = e;
+        e = safeAdd_2(d, T1);
+        d = c;
+        c = b;
+        b = a;
+        a = safeAdd_2(T1, T2);
     }
 
-    var ipad = new Array(16), opad = new Array(16);
-    for (var i = 0; i < 16; i++) {
-        ipad[i] = bkey[i] ^ 0x36363636;
-        opad[i] = bkey[i] ^ 0x5C5C5C5C;
+    H[0] = safeAdd_2(a, H[0]);
+    H[1] = safeAdd_2(b, H[1]);
+    H[2] = safeAdd_2(c, H[2]);
+    H[3] = safeAdd_2(d, H[3]);
+    H[4] = safeAdd_2(e, H[4]);
+    H[5] = safeAdd_2(f, H[5]);
+    H[6] = safeAdd_2(g, H[6]);
+    H[7] = safeAdd_2(h, H[7]);
+
+    return H;
+}
+
+/**
+ * Finalizes the SHA-2 hash
+ *
+ * @private
+ * @param {Array.<number>} remainder Any leftover unprocessed packed ints
+ *   that still need to be processed
+ * @param {number} remainderBinLen The number of bits in remainder
+ * @param {number} processedBinLen The number of bits already
+ *   processed
+ * @param {Array.<number|Int_64>} H The intermediate H values from a previous
+ *   round
+ * @param {string} variant The desired SHA-2 variant
+ * @return {Array.<number>} The array of integers representing the SHA-2
+ *   hash of message
+ */
+function finalizeSHA2(remainder, remainderBinLen, processedBinLen, H, variant)
+{
+    var i, appendedMessageLength, offset, binaryStringInc;
+
+    /* 32-bit variant */
+    /* The 65 addition is a hack but it works.  The correct number is
+       actually 72 (64 + 8) but the below math fails if
+       remainderBinLen + 72 % 512 = 0. Since remainderBinLen % 8 = 0,
+       "shorting" the addition is OK. */
+    offset = (((remainderBinLen + 65) >>> 9) << 4) + 15;
+    binaryStringInc = 16;
+
+    while (remainder.length <= offset)
+    {
+        remainder.push(0);
+    }
+    /* Append '1' at the end of the binary string */
+    remainder[remainderBinLen >>> 5] |= 0x80 << (24 - remainderBinLen % 32);
+    /* Append length of binary string in the position such that the new
+     * length is correct */
+    remainder[offset] = remainderBinLen + processedBinLen;
+
+    appendedMessageLength = remainder.length;
+
+    /* This will always be at least 1 full chunk */
+    for (i = 0; i < appendedMessageLength; i += binaryStringInc)
+    {
+        H = roundSHA2(remainder.slice(i, i + binaryStringInc), H, variant);
     }
 
-    var hash = coreSha256(ipad.concat(str2binb(data)), 512 + data.length * chrsz);
-    return coreSha256(opad.concat(hash), 512 + 256);
+    return H;
+}
+
+/**
+ * jsSHA is the workhorse of the library.  Instantiate it with the string to
+ * be hashed as the parameter
+ *
+ * @constructor
+ * @this {jsSHA}
+ * @param {string} variant The desired SHA variant (SHA-1, SHA-224, SHA-256,
+ *   SHA-384, or SHA-512)
+ * @param {string} inputFormat The format of srcString: HEX, TEXT, B64, or BYTES
+ * @param {{encoding: (string|undefined), numRounds: (string|undefined)}=}
+ *   options Optional values
+ */
+var jsSHA = function(variant, inputFormat, options)
+{
+    var processedLen = 0, remainder = [], remainderLen = 0, utfType,
+        intermediateH, converterFunc, shaVariant = variant, outputBinLen,
+        variantBlockSize, roundFunc, finalizeFunc, finalized = false,
+        hmacKeySet = false, keyWithIPad = [], keyWithOPad = [], numRounds,
+        updatedCalled = false, inputOptions;
+
+    inputOptions = options || {};
+    utfType = inputOptions["encoding"] || "UTF8";
+    numRounds = inputOptions["numRounds"] || 1;
+
+    converterFunc = getStrConverter(inputFormat, utfType);
+
+    roundFunc = function (block, H) {
+        return roundSHA2(block, H, shaVariant);
+    };
+    finalizeFunc = function (remainder, remainderBinLen, processedBinLen, H) {
+        return finalizeSHA2(remainder, remainderBinLen, processedBinLen, H, shaVariant);
+    };
+
+    variantBlockSize = 512;
+    outputBinLen = 256;
+
+    intermediateH = getH(shaVariant);
+
+    /**
+     * Sets the HMAC key for an eventual getHMAC call.  Must be called
+     * immediately after jsSHA object instantiation
+     *
+     * @expose
+     * @param {string} key The key used to calculate the HMAC
+     * @param {string} inputFormat The format of key, HEX, TEXT, B64, or BYTES
+     * @param {{encoding : (string|undefined)}=} options Associative array
+     *   of input format options
+     */
+    this.setHMACKey = function(key, inputFormat, options)
+    {
+        var keyConverterFunc, convertRet, keyBinLen, keyToUse, blockByteSize,
+            i, lastArrayIndex, keyOptions;
+
+        keyOptions = options || {};
+        utfType = keyOptions["encoding"] || "UTF8";
+
+        keyConverterFunc = getStrConverter(inputFormat, utfType);
+
+        convertRet = keyConverterFunc(key);
+        keyBinLen = convertRet["binLen"];
+        keyToUse = convertRet["value"];
+
+        blockByteSize = variantBlockSize >>> 3;
+
+        /* These are used multiple times, calculate and store them */
+        lastArrayIndex = (blockByteSize / 4) - 1;
+
+        /* Figure out what to do with the key based on its size relative to
+         * the hash's block size */
+        if (blockByteSize < (keyBinLen / 8))
+        {
+            keyToUse = finalizeFunc(keyToUse, keyBinLen, 0, getH(shaVariant));
+            /* For all variants, the block size is bigger than the output
+             * size so there will never be a useful byte at the end of the
+             * string */
+            while (keyToUse.length <= lastArrayIndex)
+            {
+                keyToUse.push(0);
+            }
+            keyToUse[lastArrayIndex] &= 0xFFFFFF00;
+        }
+        else if (blockByteSize > (keyBinLen / 8))
+        {
+            /* If the blockByteSize is greater than the key length, there
+             * will always be at LEAST one "useless" byte at the end of the
+             * string */
+            while (keyToUse.length <= lastArrayIndex)
+            {
+                keyToUse.push(0);
+            }
+            keyToUse[lastArrayIndex] &= 0xFFFFFF00;
+        }
+
+        /* Create ipad and opad */
+        for (i = 0; i <= lastArrayIndex; i += 1)
+        {
+            keyWithIPad[i] = keyToUse[i] ^ 0x36363636;
+            keyWithOPad[i] = keyToUse[i] ^ 0x5C5C5C5C;
+        }
+
+        intermediateH = roundFunc(keyWithIPad, intermediateH);
+        processedLen = variantBlockSize;
+
+        hmacKeySet = true;
+    };
+
+    /**
+     * Takes strString and hashes as many blocks as possible.  Stores the
+     * rest for either a future update or getHash call.
+     *
+     * @expose
+     * @param {string} srcString The string to be hashed
+     */
+    this.update = function(srcString)
+    {
+        var convertRet, chunkBinLen, chunkIntLen, chunk, i, updateProcessedLen = 0,
+            variantBlockIntInc = variantBlockSize >>> 5;
+
+        convertRet = converterFunc(srcString, remainder, remainderLen);
+        chunkBinLen = convertRet["binLen"];
+        chunk = convertRet["value"];
+
+        chunkIntLen = chunkBinLen >>> 5;
+        for (i = 0; i < chunkIntLen; i += variantBlockIntInc)
+        {
+            if (updateProcessedLen + variantBlockSize <= chunkBinLen)
+            {
+                intermediateH = roundFunc(
+                    chunk.slice(i, i + variantBlockIntInc),
+                    intermediateH
+                );
+                updateProcessedLen += variantBlockSize;
+            }
+        }
+        processedLen += updateProcessedLen;
+        remainder = chunk.slice(updateProcessedLen >>> 5);
+        remainderLen = chunkBinLen % variantBlockSize;
+        updatedCalled = true;
+    };
+
+    /**
+     * Returns the the HMAC in the specified format using the key given by
+     * a previous setHMACKey call.
+     *
+     * @expose
+     * @param {string} format The desired output formatting
+     *   (B64, HEX, or BYTES)
+     * @param {{outputUpper : (boolean|undefined), b64Pad : (string|undefined)}=}
+     *   options associative array of output formatting options
+     * @return {string} The string representation of the hash in the format
+     *   specified
+     */
+    this.getHMAC = function(format, options)
+    {
+        var formatFunc, firstHash, outputOptions;
+
+        outputOptions = getOutputOpts(options);
+
+        formatFunc = function(binarray) {return binb2hex(binarray, outputOptions);};
+
+        firstHash = finalizeFunc(remainder, remainderLen, processedLen, intermediateH);
+        intermediateH = roundFunc(keyWithOPad, getH(shaVariant));
+        intermediateH = finalizeFunc(firstHash, outputBinLen, variantBlockSize, intermediateH);
+
+        finalized = true;
+        return formatFunc(intermediateH);
+    };
 };
 
-exports.sha256hmac = function(key, data) {
-    return binb2hex(coreHmacSha256(key, data));
-};
+module.exports = jsSHA;
+/* eslint-enable */

--- a/lib/url/imageurl.js
+++ b/lib/url/imageurl.js
@@ -579,6 +579,7 @@ extend(ImageUrl.prototype, {
      */
     reset: function() {
         this.extension = null;
+        this.queryString = '';
         this.transformations = [];
         return this;
     },

--- a/test/unit/browser-crypto.test.js
+++ b/test/unit/browser-crypto.test.js
@@ -3,7 +3,7 @@
 var fs = require('fs'),
     path = require('path'),
     md5 = require('../../lib/browser/md5.min'),
-    sha = require('../../lib/browser/sha'),
+    sha = require('../../lib/browser/crypto').sha256,
     crypto = require('crypto'),
     assert = require('assert');
 
@@ -27,7 +27,7 @@ describe('crypto (browser)', function() {
         ].forEach(function(str) {
             var key = 'key=' + Date.now();
             assert.equal(
-                sha.sha256hmac(key, str),
+                sha(key, str),
                 crypto.createHmac('sha256', key).update(str, 'utf8').digest('hex'),
                 'String did not have correct hash'
             );
@@ -35,11 +35,23 @@ describe('crypto (browser)', function() {
             // Also test a long key (special case for this in the sha implementation)
             key += key + key + key + key + key + key;
             assert.equal(
-                sha.sha256hmac(key, str),
+                sha(key, str),
                 crypto.createHmac('sha256', key).update(str, 'utf8').digest('hex'),
                 'String did not have correct hash'
             );
         });
+    });
+
+    it('should generate correct sha256+hmac hashes for strings with special chars', function() {
+        var key = 'key=' + Date.now();
+        var str = 'https://imbo/users/dev/images.json';
+        str += '?t[]=foo&name=båt.jpg&t[]=maxSize:width=320,height=240';
+
+        assert.equal(
+            sha(key, str),
+            crypto.createHmac('sha256', key).update(str, 'utf8').digest('hex'),
+            'String did not have correct hash'
+        );
     });
 });
 

--- a/test/unit/imageurl.test.js
+++ b/test/unit/imageurl.test.js
@@ -666,6 +666,13 @@ describe('Imbo.ImageUrl', function() {
             assertUrlContains(url.flipVertically().getUrl(), 'http://imbo/users/pub/images/61da9892205a0d5077a353eb3487e8c8?t[]=flipVertically');
         });
 
+        it('should generate the correct access token when it contains special characters', function() {
+            assert.equal(
+                url.setQueryString('name=båt.jpg').flipVertically().getUrl(),
+                'http://imbo/users/pub/images/61da9892205a0d5077a353eb3487e8c8?name=båt.jpg&t%5B%5D=flipVertically&accessToken=d3e3a1889f1e2a546f23a5072f155c26ad1f1d4c214ced57b753c49e7a5803da'
+            );
+        });
+
         it('should generate correct URL-encoded URLs for advanced combinations', function() {
             assert.equal(
                 url.flipVertically().maxSize({ width: 123, height: 456 }).border({ color: '#bf1942' }).getUrl(),


### PR DESCRIPTION
Generation of access tokens failed when the data (URL in this case) contained characters outside the ASCII range. This PR replaces the old sha library with a new version (jssha). I had to strip it down somewhat to get rid of code we would never use (we only use sha256 + hmac, for instance, not the regular sha256 hashes). Even still, it adds about 2KB to the minified bundle - but at least now it'll generate correct tokens.
